### PR TITLE
allot() should not throw an error on a `null` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nillion/nilql",
-  "version": "0.0.0-alpha.9",
+  "version": "0.0.0-alpha.10",
   "description": "Library for working with encrypted data within NilDB queries and replies.",
   "license": "MIT",
   "homepage": "https://github.com/nillionnetwork/nilql-ts",

--- a/src/nilql.ts
+++ b/src/nilql.ts
@@ -840,7 +840,8 @@ function allot(document: object): object[] {
   if (
     typeof document === "number" ||
     typeof document === "boolean" ||
-    typeof document === "string"
+    typeof document === "string" ||
+    document === null
   ) {
     return [document];
   }
@@ -947,7 +948,9 @@ function allot(document: object): object[] {
     return shares;
   }
 
-  throw new TypeError("number, boolean, string, array, or object expected");
+  throw new TypeError(
+    "number, boolean, string, array, null, or object expected",
+  );
 }
 
 /**


### PR DESCRIPTION
Allow a field to have a `null` value - technically this is an Object in js, so I added a check for when `document === null` and tested on the FE data usecase

```
console.log(typeof null);
```
```
VM134:1 object
```