### PR TITLE
feat: encrypt & decrypt with seeds

### DIFF
--- a/src/nilql.ts
+++ b/src/nilql.ts
@@ -28,6 +28,11 @@ const _SECRET_SHARED_SIGNED_INTEGER_MODULUS = 2n ** 32n + 15n;
 const _PLAINTEXT_STRING_BUFFER_LEN_MAX = 4096;
 
 /**
+ * Length of random number generator seed.
+ */
+const _SEED_LEN = 64;
+
+/**
  * Mathematically standard modulus operator.
  */
 function _mod(n: bigint, m: bigint): bigint {
@@ -789,9 +794,17 @@ async function encrypt(
     const shares: Uint8Array[] = [];
     let aggregate = Buffer.alloc(buffer.length, 0);
     for (let i = 0; i < key.cluster.nodes.length - 1; i++) {
-      const mask = Buffer.from(sodium.randombytes_buf(buffer.length));
+      let mask: Buffer<ArrayBufferLike>;
+      if (buffer.length > _SEED_LEN) {
+        const seed = Buffer.from(sodium.randombytes_buf(_SEED_LEN));
+        const rand = await _randomBytes(buffer.length, seed);
+        mask = Buffer.from(rand);
+        shares.push(optionalEncrypt(seed));
+      } else {
+        mask = Buffer.from(sodium.randombytes_buf(buffer.length));
+        shares.push(optionalEncrypt(mask));
+      }
       aggregate = _xor(aggregate, mask);
-      shares.push(optionalEncrypt(mask));
     }
     shares.push(optionalEncrypt(_xor(aggregate, buffer)));
     return shares.map(_pack);
@@ -977,10 +990,17 @@ async function decrypt(
 
     // For multiple-node clusters, the plaintext is secret-shared using XOR
     // (with each share symmetrically encrypted in the case of a secret key).
-    const shares = (ciphertext as string[]).map(_unpack).map(optionalDecrypt);
+    let shares = (ciphertext as string[]).map(_unpack).map(optionalDecrypt);
+    const lens = shares.map((share) => share.length);
+    const indices = lens.map((len, i) => i).sort((a, b) => lens[b] - lens[a]);
+    shares = indices.map((i) => shares[i]);
     let buffer = Buffer.from(shares[0]);
     for (let i = 1; i < shares.length; i++) {
-      buffer = Buffer.from(_xor(buffer, Buffer.from(shares[i])));
+      let share = shares[i];
+      if (buffer.length !== share.length) {
+        share = await _randomBytes(buffer.length, share);
+      }
+      buffer = Buffer.from(_xor(buffer, Buffer.from(share)));
     }
     return _decode(buffer);
   }

--- a/tests/nilql.test.ts
+++ b/tests/nilql.test.ts
@@ -560,6 +560,34 @@ describe("encryption and decryption functions", () => {
       expect(decryptedFromBinary).toEqual(plaintextBinary);
     });
 
+    test(`encryption and decryption for large store operation (${cluster.nodes.length})`, async () => {
+      const secretKey = await nilql.SecretKey.generate(cluster, {
+        store: true,
+      });
+
+      const plaintextString = `
+      Bart Simpson is a fictional character in the American animated television series The Simpsons
+      who is part of the Simpson family. Described as one of the 100 most important people of the
+      20th century by Time, Bart was created and designed by Matt Groening in James L. Brooks's
+      office. Bart, alongside the rest of the family, debuted in the short 'Good Night' on The
+      Tracey Ullman Show on April 19, 1987. Two years later, the family received their own series,
+      which premiered on Fox on December 17, 1989. Born on April Fools' Day according to Groening,
+      Bart is ten years old; he is the eldest child and only son of Homer and Marge Simpson, and
+      has two sisters, Lisa and Maggie. Voiced by Nancy Cartwright (pictured), Bart is known for
+      his mischievousness, rebelliousness, and disrespect for authority, as well as his prank calls
+      to Moe, chalkboard gags in the opening sequence, and catchphrases. Bart is considered an
+      iconic fictional television character of the 1990s and has been called an American cultural icon.`;
+      const ciphertextFromString = await nilql.encrypt(
+        secretKey,
+        plaintextString,
+      );
+      const decryptedFromString = (await nilql.decrypt(
+        secretKey,
+        ciphertextFromString,
+      )) as string;
+      expect(decryptedFromString).toEqual(plaintextString);
+    });
+
     test(`encryption of number for match operation (${cluster.nodes.length})`, async () => {
       const secretKey = await nilql.SecretKey.generate(cluster, {
         match: true,


### PR DESCRIPTION
This PR introduces a method to create seeds instead of the regular store operation which creates secret shares. Default seed length is set to 64. In decrypt, it sorts the shares by length assuming they will either be all the same length, which means they will just be xored as before, or they will be different length, which means every share except the longest is a seed. This ensures backward compatibility as shares already uploaded would just be xored together. 
